### PR TITLE
Support turbolinks.

### DIFF
--- a/app/assets/javascripts/static_pages.coffee
+++ b/app/assets/javascripts/static_pages.coffee
@@ -1,27 +1,17 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
-$ ->
+ready = ->
   $elm = $('.js-masonry')
+  $elm.imagesLoaded().done ->
+    $elm.masonry({
+      itemSelector: '.js-masonry--item'
+      columnWidth: 290
+      gutterWidth: 10
+      isFitWidth: true
+    }) 
   $page = $('.page')
-
-
-  doMasonry = ->
-    console.log('よばれたよ')
-    $elm.imagesLoaded().done ->
-      $elm.masonry({
-        itemSelector: '.js-masonry--item'
-        columnWidth: 290
-        gutterWidth: 10
-        isFitWidth: true
-      }) 
-      return
-    return
-    
-  doMasonry()
   $page.on('click', doMasonry)
   
-  return
-  
-
-
+$(document).ready(ready)
+$(document).on('page:load', ready)


### PR DESCRIPTION
ページ遷移後にJavaScriptが有効にならないのが問題ってことですかね？

Railsはデフォルトでturbolinksが有効になっていて、リンクをクリックした時にBodyタグの中のみが書き換わるようになっているため、JavaScriptが再ロードされないので、Turbolinksを使う場合はそのための処理が必要です。
